### PR TITLE
fix: URL-encode string parameters in URL paths

### DIFF
--- a/src/metabase_mcp/client.py
+++ b/src/metabase_mcp/client.py
@@ -357,13 +357,18 @@ class MetabaseClient:
         return await self._request("GET", "/api/card/public")
 
     async def get_card_param_values(self, card_id: int, param_key: str) -> Any:
-        return await self._request("GET", f"/api/card/{card_id}/params/{param_key}/values")
+        return await self._request(
+            "GET", f"/api/card/{card_id}/params/{quote(param_key, safe='')}/values"
+        )
 
     async def search_card_param_values(
         self, card_id: int, param_key: str, query: str
     ) -> Any:
+        encoded_key = quote(param_key, safe="")
+        encoded_query = quote(query, safe="")
         return await self._request(
-            "GET", f"/api/card/{card_id}/params/{param_key}/search/{query}"
+            "GET",
+            f"/api/card/{card_id}/params/{encoded_key}/search/{encoded_query}",
         )
 
     async def get_card_param_remapping(
@@ -371,7 +376,7 @@ class MetabaseClient:
     ) -> Any:
         return await self._request(
             "GET",
-            f"/api/card/{card_id}/params/{param_key}/remapping",
+            f"/api/card/{card_id}/params/{quote(param_key, safe='')}/remapping",
             params={"value": value},
         )
 
@@ -386,7 +391,9 @@ class MetabaseClient:
         self, card_id: int, export_format: str, parameters: dict[str, Any] | None = None
     ) -> Any:
         return await self._request(
-            "POST", f"/api/card/{card_id}/query/{export_format}", json=parameters or {}
+            "POST",
+            f"/api/card/{card_id}/query/{quote(export_format, safe='')}",
+            json=parameters or {},
         )
 
     async def copy_card(self, card_id: int) -> Any:
@@ -452,7 +459,9 @@ class MetabaseClient:
         return await self._request("GET", f"/api/database/{id}/schemas")
 
     async def get_database_schema(self, id: int, schema: str) -> Any:
-        return await self._request("GET", f"/api/database/{id}/schema/{quote(schema)}")
+        return await self._request(
+            "GET", f"/api/database/{id}/schema/{quote(schema, safe='')}"
+        )
 
     async def sync_database_schema(self, id: int) -> Any:
         return await self._request("POST", f"/api/database/{id}/sync_schema")
@@ -555,7 +564,9 @@ class MetabaseClient:
             "query": query,
             "visualization_settings": visualization_settings or {},
         }
-        return await self._request("POST", f"/api/dataset/{export_format}", json=data)
+        return await self._request(
+            "POST", f"/api/dataset/{quote(export_format, safe='')}", json=data
+        )
 
     # ── Table operations ─────────────────────────────────────────────────
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -219,3 +219,27 @@ async def test_execute_card(api_key_config: MetabaseConfig) -> None:
     async with MetabaseClient(api_key_config) as client:
         result = await client.execute_card(1)
     assert result["data"]["rows"] == [[1]]
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_url_encodes_string_path_params(api_key_config: MetabaseConfig) -> None:
+    """Verify that string parameters in URL paths are properly encoded."""
+    route = respx.get(
+        "http://localhost:3000/api/card/1/params/my%20key/search/foo%2Fbar"
+    ).mock(return_value=Response(200, json={"values": []}))
+    async with MetabaseClient(api_key_config) as client:
+        await client.search_card_param_values(1, "my key", "foo/bar")
+    assert route.called
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_url_encodes_schema_param(api_key_config: MetabaseConfig) -> None:
+    """Verify that schema name with special chars is encoded in path."""
+    route = respx.get(
+        "http://localhost:3000/api/database/1/schema/public%2Ftest"
+    ).mock(return_value=Response(200, json=[]))
+    async with MetabaseClient(api_key_config) as client:
+        await client.get_database_schema(1, "public/test")
+    assert route.called


### PR DESCRIPTION
## Summary

- Applied `quote(param, safe='')` to all string parameters interpolated in URL paths
- Affected methods: `get_card_param_values`, `search_card_param_values`, `get_card_param_remapping`, `execute_card_query_with_format`, `execute_query_export`
- Standardized existing `get_database_schema` to use `safe=''` for consistency
- Added 2 tests verifying encoding of special characters (spaces, slashes)

Closes #3

## Test plan

- [x] 70 unit tests pass (2 new)
- [x] ruff check passes
- [x] mypy passes
- [x] Tests verify `my key` → `my%20key` and `foo/bar` → `foo%2Fbar` in URLs