### PR TITLE
fix: sanitize response.text in error messages

### DIFF
--- a/src/metabase_mcp/client.py
+++ b/src/metabase_mcp/client.py
@@ -107,8 +107,9 @@ class MetabaseClient:
             raise MetabaseError(f"HTTP error: {method} {path}: {e}") from e
 
         if response.status_code in (401, 403):
+            logger.debug("Auth error response: %s", response.text)
             raise MetabaseAuthError(
-                f"Authentication failed: {response.text}",
+                f"Authentication failed: {method} {path} (HTTP {response.status_code})",
                 status_code=response.status_code,
             )
         if response.status_code == 404:
@@ -117,8 +118,9 @@ class MetabaseClient:
                 status_code=404,
             )
         if response.status_code >= 400:
+            logger.debug("API error response: %s", response.text)
             raise MetabaseAPIError(
-                f"API error: {response.text}",
+                f"API error: {method} {path} (HTTP {response.status_code})",
                 status_code=response.status_code,
             )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -150,8 +150,10 @@ async def test_error_401_raises_auth_error(api_key_config: MetabaseConfig) -> No
         return_value=Response(401, text="Unauthorized")
     )
     async with MetabaseClient(api_key_config) as client:
-        with pytest.raises(MetabaseAuthError):
+        with pytest.raises(MetabaseAuthError) as exc_info:
             await client.get_databases()
+    assert "Unauthorized" not in str(exc_info.value)
+    assert "HTTP 401" in str(exc_info.value)
 
 
 @respx.mock
@@ -161,8 +163,10 @@ async def test_error_403_raises_auth_error(api_key_config: MetabaseConfig) -> No
         return_value=Response(403, text="Forbidden")
     )
     async with MetabaseClient(api_key_config) as client:
-        with pytest.raises(MetabaseAuthError):
+        with pytest.raises(MetabaseAuthError) as exc_info:
             await client.get_dashboards()
+    assert "Forbidden" not in str(exc_info.value)
+    assert "HTTP 403" in str(exc_info.value)
 
 
 @respx.mock
@@ -178,13 +182,16 @@ async def test_error_404_raises_not_found(api_key_config: MetabaseConfig) -> Non
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_error_500_raises_api_error(api_key_config: MetabaseConfig) -> None:
+async def test_error_500_does_not_leak_response_body(api_key_config: MetabaseConfig) -> None:
+    sensitive_body = '{"message":"User admin@corp.com lacks permission"}'
     respx.get("http://localhost:3000/api/database").mock(
-        return_value=Response(500, text="Internal Server Error")
+        return_value=Response(500, text=sensitive_body)
     )
     async with MetabaseClient(api_key_config) as client:
-        with pytest.raises(MetabaseAPIError):
+        with pytest.raises(MetabaseAPIError) as exc_info:
             await client.get_databases()
+    assert "admin@corp.com" not in str(exc_info.value)
+    assert "HTTP 500" in str(exc_info.value)
 
 
 @respx.mock


### PR DESCRIPTION
## Summary

- Removed raw `response.text` from exception messages in `_request()`
- Error messages now include only: HTTP method, path, and status code
- `response.text` is logged at `DEBUG` level for local troubleshooting
- Updated tests to verify error messages don't leak response body content

Closes #4

## Test plan

- [x] All 68 unit tests pass
- [x] Tests verify `"Unauthorized"` is NOT in 401 error message
- [x] Tests verify `"admin@corp.com"` is NOT in 500 error message
- [x] Tests verify `"HTTP 4xx"` IS in error messages
- [x] ruff and mypy pass