### PR TITLE
Add Portuguese (pt-BR) documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Session token automatic refresh with TTL tracking and 401-based re-authentication in `MetabaseAuth` (#2)
 - Comprehensive test suite: 190 tests with 84% coverage (up from 51%) (#6)
 - `pytest-cov` dev dependency and `--cov-fail-under=80` enforcement in CI (#6)
+- Portuguese (pt-BR) documentation: translated README, architecture guide, and tools reference (#11)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Language**: English | [Portugues (BR)](README.pt-BR.md)
+
 # metabase-mcp-python
 
 A Python [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for [Metabase](https://www.metabase.com/), enabling AI assistants to query databases, manage dashboards, and interact with your Metabase instance.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,180 @@
+> **Idioma**: [English](README.md) | Portugues (BR)
+
+# metabase-mcp-python
+
+Um servidor [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) em Python para o [Metabase](https://www.metabase.com/), permitindo que assistentes de IA consultem bancos de dados, gerenciem dashboards e interajam com sua instancia do Metabase.
+
+Inspirado no [CognitionAI/metabase-mcp-server](https://github.com/CognitionAI/metabase-mcp-server) (TypeScript). Veja [CREDITS.md](CREDITS.md) para atribuicao.
+
+## Instalacao
+
+### Com uv (recomendado)
+
+```bash
+uv tool install metabase-mcp-python
+```
+
+### Com pip
+
+```bash
+pip install metabase-mcp-python
+```
+
+### A partir do codigo fonte
+
+```bash
+git clone https://github.com/im-voracity/metabase-mcp-python.git
+cd metabase-mcp-python
+uv sync
+```
+
+## Configuracao
+
+Defina as seguintes variaveis de ambiente (ou use um arquivo `.env`):
+
+| Variavel | Obrigatoria | Descricao |
+|---|---|---|
+| `METABASE_URL` | Sim | URL da sua instancia Metabase (ex: `http://localhost:3000`) |
+| `METABASE_API_KEY` | Uma das | Chave de API do Metabase para autenticacao |
+| `METABASE_USERNAME` | Uma das | Usuario para autenticacao via sessao |
+| `METABASE_PASSWORD` | Uma das | Senha para autenticacao via sessao |
+
+Voce deve fornecer `METABASE_API_KEY` ou ambos `METABASE_USERNAME` e `METABASE_PASSWORD`.
+
+## Uso
+
+### Claude Desktop
+
+Adicione ao seu `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "metabase": {
+      "command": "uv",
+      "args": ["tool", "run", "metabase-mcp-python"],
+      "env": {
+        "METABASE_URL": "http://localhost:3000",
+        "METABASE_API_KEY": "sua-chave-api"
+      }
+    }
+  }
+}
+```
+
+Com autenticacao via sessao:
+
+```json
+{
+  "mcpServers": {
+    "metabase": {
+      "command": "uv",
+      "args": ["tool", "run", "metabase-mcp-python"],
+      "env": {
+        "METABASE_URL": "http://localhost:3000",
+        "METABASE_USERNAME": "usuario@exemplo.com",
+        "METABASE_PASSWORD": "sua-senha"
+      }
+    }
+  }
+}
+```
+
+### Claude CLI
+
+```json
+{
+  "mcpServers": {
+    "metabase": {
+      "command": "uv",
+      "args": ["tool", "run", "metabase-mcp-python", "--write"],
+      "env": {
+        "METABASE_URL": "http://localhost:3000",
+        "METABASE_API_KEY": "sua-chave-api"
+      }
+    }
+  }
+}
+```
+
+### Executando a partir do codigo fonte
+
+```json
+{
+  "mcpServers": {
+    "metabase": {
+      "command": "uv",
+      "args": ["run", "--directory", "/caminho/para/metabase-mcp-python", "metabase-mcp"],
+      "env": {
+        "METABASE_URL": "http://localhost:3000",
+        "METABASE_API_KEY": "sua-chave-api"
+      }
+    }
+  }
+}
+```
+
+## Modos de Filtragem de Tools
+
+O servidor suporta tres modos para controlar quais tools sao expostas ao assistente de IA:
+
+| Modo | Flag | Tools | Descricao |
+|---|---|---|---|
+| Essential | `--essential` (padrao) | ~19 | Operacoes de leitura basicas para consulta e exploracao |
+| Write | `--write` | ~59 | Essential + operacoes de criacao, atualizacao e exclusao |
+| All | `--all` | ~87 | Todas as tools disponiveis, incluindo operacoes avancadas |
+
+Exemplos:
+
+```bash
+metabase-mcp                # Modo essential (padrao)
+metabase-mcp --write        # Essential + tools de escrita
+metabase-mcp --all          # Todas as tools
+```
+
+O modo essential e o padrao para manter a lista de tools gerenciavel e reduzir o risco de modificacoes nao intencionais. Use `--write` ou `--all` quando precisar criar ou modificar recursos no Metabase.
+
+## Tools Disponiveis
+
+As tools sao organizadas em cinco categorias:
+
+- **Database** (13 tools) -- Listar, inspecionar, criar e gerenciar conexoes de banco de dados; executar queries SQL
+- **Table** (17 tools) -- Navegar tabelas, inspecionar schemas, gerenciar metadados de campos, importar/exportar CSV
+- **Card** (21 tools) -- CRUD de perguntas salvas, executar queries, gerenciar links publicos, mover cards
+- **Dashboard** (27 tools) -- CRUD de dashboards, gerenciar cards/layout, auditoria de filtros, links publicos
+- **Additional** (9 tools) -- Collections, busca, usuarios, links de playground
+
+Veja [docs/pt-BR/tools-reference.md](docs/pt-BR/tools-reference.md) para a listagem completa de tools.
+
+## Desenvolvimento
+
+### Setup
+
+```bash
+git clone https://github.com/im-voracity/metabase-mcp-python.git
+cd metabase-mcp-python
+uv sync --group dev
+```
+
+### Testes
+
+```bash
+uv run pytest
+uv run pytest -m "not integration"    # Pular testes de integracao
+```
+
+### Linting e verificacao de tipos
+
+```bash
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run mypy src
+```
+
+## Arquitetura
+
+Veja [docs/pt-BR/architecture.md](docs/pt-BR/architecture.md) para uma visao detalhada da estrutura do codigo, fluxo de requisicoes e sistema de autenticacao.
+
+## Licenca
+
+[MIT](LICENSE)

--- a/docs/pt-BR/architecture.md
+++ b/docs/pt-BR/architecture.md
@@ -1,0 +1,113 @@
+# Arquitetura
+
+## Visao Geral dos Componentes
+
+```
++------------------+     +------------------+     +----------------+     +------------------+
+|                  |     |                  |     |                |     |                  |
+|  MetabaseConfig  +---->+  MetabaseClient  +---->+  Tool modules  +---->+  FastMCP Server  |
+|  (config.py)     |     |  (client.py)     |     |  (tools/*.py)  |     |  (server.py)     |
+|                  |     |                  |     |                |     |                  |
++------------------+     +------------------+     +----------------+     +------------------+
+       |                        |                        |                        |
+  Env vars / .env         httpx.AsyncClient        @mcp.tool()              stdio transport
+  pydantic-settings       MetabaseAuth             Tool filtering           MCP protocol
+```
+
+### MetabaseConfig (`src/metabase_mcp/config.py`)
+
+Carrega a configuracao a partir de variaveis de ambiente usando `pydantic-settings`. Valida que `METABASE_URL` e uma URL bem formada e que uma chave de API ou credenciais de usuario/senha foram fornecidas.
+
+### MetabaseClient (`src/metabase_mcp/client.py`)
+
+Client HTTP assincrono que encapsula a API REST do Metabase. Usa `httpx.AsyncClient` com um handler customizado `MetabaseAuth`. Fornece metodos tipados para cada endpoint suportado da API (dashboards, cards, databases, tables, collections, users, permissions, activity).
+
+### Tool Modules (`src/metabase_mcp/tools/`)
+
+Cada modulo registra um grupo de tools MCP via decoradores `@mcp.tool()`:
+
+- `database.py` -- Conexoes de banco de dados, queries, inspecao de schema
+- `table.py` -- Metadados de tabelas, operacoes de campos, importacao/exportacao CSV
+- `card.py` -- CRUD de perguntas salvas, execucao, links publicos
+- `dashboard.py` -- CRUD de dashboards, layout de cards, auditoria de filtros
+- `additional.py` -- Collections, busca, usuarios, links de playground
+
+### FastMCP Server (`src/metabase_mcp/server.py`)
+
+Cria a instancia `FastMCP`, inicializa o client e registra todas as tools. A filtragem de tools e aplicada apos o registro, removendo as tools que nao correspondem ao modo selecionado.
+
+### Entry Point (`src/metabase_mcp/__main__.py`)
+
+Faz o parsing dos argumentos CLI (`--essential`, `--write`, `--all`), cria o server e o inicia com transporte stdio.
+
+## Fluxo de Requisicao
+
+```
+MCP Client (Claude, etc.)
+    |
+    |  MCP protocol (stdio)
+    v
+FastMCP Server
+    |
+    |  Roteia para a funcao de tool registrada
+    v
+Funcao de tool (ex: list_dashboards)
+    |
+    |  Chama metodo do client
+    v
+MetabaseClient._request()
+    |
+    |  httpx.AsyncClient com MetabaseAuth
+    v
+Metabase REST API
+```
+
+1. O client MCP envia uma requisicao de chamada de tool via stdio.
+2. O FastMCP despacha a chamada para a funcao de tool correspondente.
+3. A funcao de tool chama o metodo apropriado do `MetabaseClient`.
+4. `MetabaseClient._request()` envia a requisicao HTTP via `httpx.AsyncClient`.
+5. `MetabaseAuth` injeta o header de autenticacao (chave de API ou token de sessao).
+6. A resposta e parseada, verificada quanto a erros e retornada como JSON.
+
+## Autenticacao
+
+A autenticacao e gerenciada pelo `MetabaseAuth`, uma subclasse de `httpx.Auth` que implementa o generator `auth_flow()`:
+
+- **Chave de API**: Define o header `X-API-Key` em cada requisicao. Sem round-trips adicionais.
+- **Token de sessao**: Na primeira requisicao, faz yield de uma sub-requisicao para `POST /api/session` com usuario/senha. O token de sessao retornado e armazenado em cache e definido como `X-Metabase-Session` nas requisicoes subsequentes.
+
+Isso substitui o padrao de request interceptor do axios da implementacao original em TypeScript. A abordagem `httpx.Auth` e idiomatica em Python e permite que o httpx gerencie o fluxo de autenticacao de forma transparente.
+
+### Tratamento de Redirecionamentos
+
+`MetabaseClient._request()` trata redirecionamentos HTTP-para-HTTPS manualmente (ate 3 saltos) para preservar o metodo HTTP original. O comportamento padrao `follow_redirects` do httpx converte POST/PUT em GET em redirecionamentos 301/302, o que quebra chamadas de API.
+
+## Filtragem de Tools
+
+O registro de tools (`src/metabase_mcp/tools/__init__.py`) define tres conjuntos:
+
+- **ESSENTIAL_TOOLS**: ~19 tools core somente leitura para consulta e exploracao.
+- **WRITE_TOOLS**: ~40 tools adicionais que criam, atualizam ou excluem recursos.
+- **Todas as tools**: O conjunto completo de ~87 tools em todos os modulos.
+
+A filtragem funciona registrando todas as tools primeiro e depois removendo aquelas que nao correspondem ao modo selecionado. Essa abordagem evita logica condicional dentro de cada modulo de tools.
+
+| Modo | Inclui |
+|---|---|
+| `essential` | Apenas tools em `ESSENTIAL_TOOLS` |
+| `write` | Tools em `ESSENTIAL_TOOLS` + `WRITE_TOOLS` |
+| `all` | Todas as tools registradas |
+
+## Adicionando Novas Tools
+
+1. Identifique o endpoint da API do Metabase e adicione um metodo ao `MetabaseClient` em `client.py`.
+2. Crie a funcao de tool no modulo apropriado em `tools/` usando `@mcp.tool()`.
+3. Se a tool deve estar disponivel no modo essential ou write, adicione seu nome ao conjunto correspondente em `tools/__init__.py`.
+4. Adicione testes em `tests/tools/`.
+
+### Convencoes para funcoes de tool
+
+- Use `Annotated[type, Field(description="...")]` para todos os parametros.
+- Defina `annotations=ToolAnnotations(readOnlyHint=True)` para operacoes de leitura, `readOnlyHint=False` para escritas, e adicione `destructiveHint=True` para exclusoes.
+- Retorne `json.dumps(result, indent=2)` como string.
+- Use validadores de `validators.py` (`JsonParsed`, `JsonParsedList`, `parse_if_string`) para parametros que podem chegar como JSON strings.

--- a/docs/pt-BR/tools-reference.md
+++ b/docs/pt-BR/tools-reference.md
@@ -1,0 +1,117 @@
+# Referencia de Tools
+
+Listagem completa de todas as 87 tools MCP, organizadas por categoria. A disponibilidade de cada tool depende do [modo de filtragem](../../README.pt-BR.md#modos-de-filtragem-de-tools) selecionado.
+
+**Legenda**: E = essential, W = write, A = all-only
+
+## Database (13 tools)
+
+| Tool | Modo | Descricao |
+|---|---|---|
+| `list_databases` | E | Recuperar todas as conexoes de banco de dados no Metabase |
+| `get_database` | E | Recuperar informacoes detalhadas sobre um banco de dados especifico |
+| `execute_query` | E | Executar uma query SQL nativa em um banco de dados |
+| `create_database` | W | Adicionar uma nova conexao de banco de dados ao Metabase |
+| `update_database` | W | Atualizar configuracao do banco (nome, conexao, sincronizacao) |
+| `delete_database` | W | Remover permanentemente um banco de dados do Metabase |
+| `validate_database` | A | Testar parametros de conexao antes de criar |
+| `add_sample_database` | W | Adicionar o banco de dados de exemplo embutido do Metabase |
+| `check_database_health` | A | Verificar a saude de uma conexao de banco de dados |
+| `get_database_metadata` | A | Recuperar metadados abrangentes (tabelas, campos, relacionamentos) |
+| `list_database_schemas` | A | Recuperar todos os nomes de schema em um banco de dados |
+| `get_database_schema` | A | Recuperar informacoes detalhadas sobre um schema especifico |
+| `sync_database_schema` | W | Iniciar sincronizacao de schema para atualizar o cache de metadados |
+
+## Table (17 tools)
+
+| Tool | Modo | Descricao |
+|---|---|---|
+| `list_tables` | E | Recuperar todas as tabelas com filtragem opcional por ID |
+| `get_table` | E | Recuperar informacoes completas da tabela incluindo schema e campos |
+| `get_field_id` | E | Buscar o ID e metadados de um campo por tabela e nome da coluna |
+| `get_table_data` | E | Recuperar dados de amostra de uma tabela para preview |
+| `update_tables` | W | Atualizar multiplas tabelas em lote com a mesma configuracao |
+| `update_table` | W | Atualizar nome de exibicao, descricao e configuracoes de uma tabela |
+| `get_table_fks` | A | Recuperar relacionamentos de chave estrangeira de uma tabela |
+| `get_table_query_metadata` | A | Recuperar metadados de tabela otimizados para queries |
+| `get_table_related` | A | Encontrar tabelas e entidades relacionadas |
+| `get_card_table_fks` | A | Recuperar chaves estrangeiras da tabela virtual de um card |
+| `get_card_table_query_metadata` | A | Recuperar metadados de query da tabela virtual de um card |
+| `append_csv_to_table` | W | Adicionar novas linhas de conteudo CSV a uma tabela existente |
+| `discard_table_field_values` | W | Limpar valores de campo em cache para forcar recarregamento |
+| `reorder_table_fields` | W | Alterar a ordem de exibicao dos campos da tabela |
+| `replace_table_csv` | W | Substituir completamente os dados da tabela com novo conteudo CSV |
+| `rescan_table_field_values` | W | Disparar re-escaneamento para atualizar cache de valores de campo |
+| `sync_table_schema` | W | Iniciar sincronizacao de schema para uma tabela especifica |
+
+## Card (21 tools)
+
+| Tool | Modo | Descricao |
+|---|---|---|
+| `list_cards` | E | Recuperar todos os cards com filtragem opcional por tipo de fonte |
+| `get_card` | E | Obter metadados e configuracao completos de um card especifico |
+| `execute_card` | E | Executar a query de um card e retornar os dados resultantes |
+| `get_card_dashboards` | E | Encontrar todos os dashboards que incluem um card especifico |
+| `create_card` | W | Criar um novo card com query e visualizacao customizadas |
+| `update_card` | W | Modificar nome, query, visualizacao ou configuracoes de um card |
+| `delete_card` | W | Remover um card (arquivar ou exclusao permanente) |
+| `copy_card` | W | Criar uma copia duplicada de um card existente |
+| `move_cards` | W | Realocar multiplos cards para uma collection ou dashboard diferente |
+| `move_cards_to_collection` | W | Transferir multiplos cards em lote para uma collection especifica |
+| `create_card_public_link` | W | Gerar uma URL publicamente acessivel para um card |
+| `delete_card_public_link` | W | Remover acesso publico a um card |
+| `export_card_result` | A | Executar um card e exportar resultados em formato especifico (CSV, XLSX, JSON) |
+| `list_embeddable_cards` | A | Recuperar todos os cards configurados para embedding |
+| `list_public_cards` | A | Recuperar todos os cards com URLs publicas habilitadas |
+| `execute_pivot_card_query` | A | Executar um card com formatacao de tabela pivot |
+| `get_card_param_values` | A | Recuperar valores disponiveis para um parametro de card |
+| `search_card_param_values` | A | Pesquisar e filtrar valores de parametros disponiveis |
+| `get_card_param_remapping` | A | Recuperar como valores de parametro sao remapeados para exibicao |
+| `get_card_query_metadata` | A | Recuperar metadados estruturais sobre a query de um card |
+| `get_card_series` | A | Recuperar dados de series temporais ou sugestoes de cards relacionados |
+
+## Dashboard (27 tools)
+
+| Tool | Modo | Descricao |
+|---|---|---|
+| `list_dashboards` | E | Recuperar todos os dashboards |
+| `get_dashboard` | E | Recuperar informacoes detalhadas sobre um dashboard especifico |
+| `get_dashboard_cards` | E | Recuperar todos os cards dentro de um dashboard especifico |
+| `create_dashboard` | E/W | Criar um novo dashboard |
+| `create_public_link` | W | Gerar uma URL publicamente acessivel para um dashboard |
+| `copy_dashboard` | W | Criar uma copia de um dashboard existente com todos os cards |
+| `add_card_to_dashboard` | W | Adicionar um card existente a um dashboard |
+| `add_text_block` | W | Adicionar um bloco de texto ou titulo a um dashboard |
+| `update_dashboard` | W | Atualizar propriedades do dashboard (nome, descricao, parametros) |
+| `update_dashboard_cards` | W | Substituir todos os cards do dashboard (destrutivo) |
+| `update_dashcard` | W | Atualizar propriedades de um dashcard especifico |
+| `delete_dashboard` | W | Excluir ou arquivar um dashboard |
+| `delete_public_link` | W | Remover acesso por URL publica de um dashboard |
+| `remove_cards_from_dashboard` | W | Remover dashcards especificos de um dashboard |
+| `favorite_dashboard` | W | Marcar um dashboard como favorito |
+| `unfavorite_dashboard` | W | Remover um dashboard dos favoritos |
+| `revert_dashboard` | W | Restaurar um dashboard para uma revisao anterior |
+| `save_dashboard` | W | Salvar um objeto de dashboard completo |
+| `save_dashboard_to_collection` | W | Salvar um dashboard em uma collection especifica |
+| `get_dashboard_related` | A | Recuperar entidades relacionadas a um dashboard |
+| `get_dashboard_revisions` | A | Recuperar historico de revisoes de um dashboard |
+| `list_embeddable_dashboards` | A | Recuperar todos os dashboards configurados para embedding |
+| `list_public_dashboards` | A | Recuperar todos os dashboards com URLs publicas habilitadas |
+| `search_dashboards` | A | Pesquisar dashboards por nome ou descricao |
+| `execute_dashboard_card` | A | Executar um card especifico de um dashboard |
+| `get_dashboard_queries` | A | Extrair todas as queries de um dashboard com nomes resolvidos |
+| `audit_dashboard_filters` | A | Analisar conexoes de filtros para encontrar configuracoes incorretas |
+
+## Additional (9 tools)
+
+| Tool | Modo | Descricao |
+|---|---|---|
+| `list_collections` | E | Recuperar todas as collections |
+| `get_collection_items` | E | Recuperar todos os itens dentro de uma collection |
+| `search_content` | E | Pesquisar em todo o conteudo do Metabase |
+| `get_metabase_playground_link` | E | Gerar um link de playground do Metabase para exploracao interativa |
+| `create_collection` | W | Criar uma nova collection |
+| `update_collection` | W | Atualizar propriedades de uma collection |
+| `delete_collection` | W | Excluir permanentemente uma collection |
+| `move_to_collection` | W | Mover um card ou dashboard para uma collection diferente |
+| `list_users` | A | Recuperar todos os usuarios do Metabase com funcoes e permissoes |


### PR DESCRIPTION
## Summary
- Translated README to Brazilian Portuguese (`README.pt-BR.md`) with all sections and examples
- Added `docs/pt-BR/architecture.md` and `docs/pt-BR/tools-reference.md` with full translations
- Added language toggle links at the top of both README versions
- Updated CHANGELOG with #11 entry

Closes #11

## Test plan
- [ ] Verify all internal links between pt-BR docs resolve correctly
- [ ] Verify language toggle links work in both READMEs
- [ ] Confirm CI passes (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)