### PR TITLE
feat: add dashboard tab management tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Dashboard tab management tools: `create_dashboard_tab`, `update_dashboard_tab`, `delete_dashboard_tab` (#21)
+- `_clean_dashcards()` static helper to normalize dashcard payloads, reused across tab and card operations (#21)
 - Session token automatic refresh with TTL tracking and 401-based re-authentication in `MetabaseAuth` (#2)
 - Comprehensive test suite: 190 tests with 84% coverage (up from 51%) (#6)
 - `pytest-cov` dev dependency and `--cov-fail-under=80` enforcement in CI (#6)

--- a/src/metabase_mcp/client.py
+++ b/src/metabase_mcp/client.py
@@ -227,25 +227,7 @@ class MetabaseClient:
         if "dashboard_tab_id" in card_data:
             new_dashcard["dashboard_tab_id"] = card_data["dashboard_tab_id"]
 
-        cleaned = [
-            {
-                "id": dc["id"],
-                "card_id": dc.get("card_id"),
-                "row": dc.get("row", 0),
-                "col": dc.get("col", 0),
-                "size_x": dc.get("size_x", 12),
-                "size_y": dc.get("size_y", 8),
-                "series": dc.get("series", []),
-                "visualization_settings": dc.get("visualization_settings", {}),
-                "parameter_mappings": dc.get("parameter_mappings", []),
-                **(
-                    {"dashboard_tab_id": dc["dashboard_tab_id"]}
-                    if "dashboard_tab_id" in dc
-                    else {}
-                ),
-            }
-            for dc in existing_dashcards
-        ]
+        cleaned = self._clean_dashcards(existing_dashcards)
 
         return await self._request(
             "PUT",
@@ -311,6 +293,95 @@ class MetabaseClient:
         return await self._request(
             "POST", f"/api/dashboard/save/collection/{parent_collection_id}", json=dashboard
         )
+
+    # ── Dashboard tab operations ──────────────────────────────────────────
+    #
+    # Metabase manages tabs atomically through PUT /api/dashboard/:id
+    # with the full tabs + dashcards arrays. There are no dedicated
+    # tab sub-resource endpoints.
+
+    async def create_dashboard_tab(self, dashboard_id: int, name: str) -> Any:
+        dashboard = await self.get_dashboard(dashboard_id)
+        existing_tabs = dashboard.get("tabs", [])
+        existing_dashcards = dashboard.get("dashcards", [])
+        new_tab = {"id": -1, "name": name}
+        result = await self._request(
+            "PUT",
+            f"/api/dashboard/{dashboard_id}",
+            json={
+                "dashcards": self._clean_dashcards(existing_dashcards),
+                "tabs": [*existing_tabs, new_tab],
+            },
+        )
+        # Return only the newly created tab (last one with a new id)
+        existing_ids = {t["id"] for t in existing_tabs}
+        for tab in reversed(result.get("tabs", [])):
+            if tab["id"] not in existing_ids:
+                return tab
+        return result.get("tabs", [])[-1] if result.get("tabs") else result
+
+    async def update_dashboard_tab(
+        self, dashboard_id: int, tab_id: int, name: str
+    ) -> Any:
+        dashboard = await self.get_dashboard(dashboard_id)
+        tabs = dashboard.get("tabs", [])
+        existing_dashcards = dashboard.get("dashcards", [])
+        updated_tabs = [
+            {**t, "name": name} if t["id"] == tab_id else t for t in tabs
+        ]
+        result = await self._request(
+            "PUT",
+            f"/api/dashboard/{dashboard_id}",
+            json={
+                "dashcards": self._clean_dashcards(existing_dashcards),
+                "tabs": updated_tabs,
+            },
+        )
+        for tab in result.get("tabs", []):
+            if tab["id"] == tab_id:
+                return tab
+        return result
+
+    async def delete_dashboard_tab(self, dashboard_id: int, tab_id: int) -> Any:
+        dashboard = await self.get_dashboard(dashboard_id)
+        tabs = dashboard.get("tabs", [])
+        existing_dashcards = dashboard.get("dashcards", [])
+        filtered_tabs = [t for t in tabs if t["id"] != tab_id]
+        # Also remove dashcards assigned to the deleted tab
+        filtered_dashcards = [
+            dc for dc in existing_dashcards if dc.get("dashboard_tab_id") != tab_id
+        ]
+        return await self._request(
+            "PUT",
+            f"/api/dashboard/{dashboard_id}",
+            json={
+                "dashcards": self._clean_dashcards(filtered_dashcards),
+                "tabs": filtered_tabs,
+            },
+        )
+
+    @staticmethod
+    def _clean_dashcards(dashcards: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Normalize dashcards for PUT /api/dashboard/:id payload."""
+        return [
+            {
+                "id": dc["id"],
+                "card_id": dc.get("card_id"),
+                "row": dc.get("row", 0),
+                "col": dc.get("col", 0),
+                "size_x": dc.get("size_x", 12),
+                "size_y": dc.get("size_y", 8),
+                "series": dc.get("series", []),
+                "visualization_settings": dc.get("visualization_settings", {}),
+                "parameter_mappings": dc.get("parameter_mappings", []),
+                **(
+                    {"dashboard_tab_id": dc["dashboard_tab_id"]}
+                    if "dashboard_tab_id" in dc
+                    else {}
+                ),
+            }
+            for dc in dashcards
+        ]
 
     # ── Card operations ──────────────────────────────────────────────────
 

--- a/src/metabase_mcp/tools/__init__.py
+++ b/src/metabase_mcp/tools/__init__.py
@@ -62,6 +62,9 @@ WRITE_TOOLS: set[str] = {
     "revert_dashboard",
     "save_dashboard",
     "save_dashboard_to_collection",
+    "create_dashboard_tab",
+    "update_dashboard_tab",
+    "delete_dashboard_tab",
     # Card write
     "create_card",
     "update_card",

--- a/src/metabase_mcp/tools/dashboard.py
+++ b/src/metabase_mcp/tools/dashboard.py
@@ -704,3 +704,45 @@ def register_dashboard_tools(mcp: FastMCP, client: MetabaseClient) -> None:
         """Remove a dashboard from the user's favorites list - use this to clean up bookmarked dashboards"""
         result = await client.unfavorite_dashboard(dashboard_id)
         return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def create_dashboard_tab(
+        dashboard_id: Annotated[int, Field(description="The ID of the dashboard")],
+        name: Annotated[str, Field(description="Name for the new tab")],
+    ) -> str:
+        """Create a new tab on a dashboard - use this to organize dashboard content into separate tabbed views"""
+        result = await client.create_dashboard_tab(dashboard_id, name)
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def update_dashboard_tab(
+        dashboard_id: Annotated[int, Field(description="The ID of the dashboard")],
+        tab_id: Annotated[int, Field(description="The ID of the tab to update")],
+        name: Annotated[str, Field(description="New name for the tab")],
+    ) -> str:
+        """Rename a tab on a dashboard - use this to update tab labels for clarity or reorganization"""
+        result = await client.update_dashboard_tab(dashboard_id, tab_id, name)
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+    )
+    async def delete_dashboard_tab(
+        dashboard_id: Annotated[int, Field(description="The ID of the dashboard")],
+        tab_id: Annotated[int, Field(description="The ID of the tab to delete")],
+    ) -> str:
+        """Delete a tab from a dashboard - WARNING: this may remove or reassign cards on the tab"""
+        await client.delete_dashboard_tab(dashboard_id, tab_id)
+        return json.dumps(
+            {
+                "dashboard_id": dashboard_id,
+                "tab_id": tab_id,
+                "action": "deleted",
+                "status": "success",
+            },
+            indent=2,
+        )

--- a/tests/integration/test_dashboards.py
+++ b/tests/integration/test_dashboards.py
@@ -106,3 +106,43 @@ async def test_dashboard_with_card(
     finally:
         await client.delete_dashboard(dashboard["id"], hard_delete=True)
         await client.delete_card(card["id"], hard_delete=True)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_dashboard_tab_crud(
+    client: MetabaseClient, test_collection: dict[str, Any]
+) -> None:
+    """Full CRUD cycle for dashboard tabs."""
+    dashboard = await client.create_dashboard(
+        {
+            "name": "Tab Test Dashboard",
+            "collection_id": test_collection["id"],
+        }
+    )
+    dashboard_id = dashboard["id"]
+
+    try:
+        # Create tab
+        tab = await client.create_dashboard_tab(dashboard_id, "First Tab")
+        assert tab["name"] == "First Tab"
+        tab_id = tab["id"]
+
+        # Update tab
+        updated = await client.update_dashboard_tab(dashboard_id, tab_id, "Renamed Tab")
+        assert updated["name"] == "Renamed Tab"
+
+        # Verify tab exists on dashboard
+        fetched = await client.get_dashboard(dashboard_id)
+        tabs = fetched.get("tabs", [])
+        assert any(t["id"] == tab_id for t in tabs)
+
+        # Delete tab
+        await client.delete_dashboard_tab(dashboard_id, tab_id)
+
+        # Verify tab is gone
+        fetched = await client.get_dashboard(dashboard_id)
+        tabs = fetched.get("tabs", [])
+        assert not any(t["id"] == tab_id for t in tabs)
+
+    finally:
+        await client.delete_dashboard(dashboard_id, hard_delete=True)

--- a/tests/tools/test_dashboard.py
+++ b/tests/tools/test_dashboard.py
@@ -576,3 +576,51 @@ async def test_audit_dashboard_filters_missing_stage(
     data = json.loads(result.content[0].text)
     assert len(data["all_cards"][0]["errors"]) == 1
     assert "stage-number" in data["all_cards"][0]["errors"][0]
+
+
+# ── Dashboard tab tools ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_dashboard_tab_tool(
+    mcp_with_dash_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.create_dashboard_tab.return_value = {"id": 10, "name": "Overview"}
+    result = await mcp_with_dash_tools.call_tool(
+        "create_dashboard_tab",
+        {"dashboard_id": 1, "name": "Overview"},
+    )
+    mock_client.create_dashboard_tab.assert_awaited_once_with(1, "Overview")
+    data = json.loads(result.content[0].text)
+    assert data["name"] == "Overview"
+    assert data["id"] == 10
+
+
+@pytest.mark.asyncio
+async def test_update_dashboard_tab_tool(
+    mcp_with_dash_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.update_dashboard_tab.return_value = {"id": 10, "name": "Renamed"}
+    result = await mcp_with_dash_tools.call_tool(
+        "update_dashboard_tab",
+        {"dashboard_id": 1, "tab_id": 10, "name": "Renamed"},
+    )
+    mock_client.update_dashboard_tab.assert_awaited_once_with(1, 10, "Renamed")
+    data = json.loads(result.content[0].text)
+    assert data["name"] == "Renamed"
+
+
+@pytest.mark.asyncio
+async def test_delete_dashboard_tab_tool(
+    mcp_with_dash_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.delete_dashboard_tab.return_value = None
+    result = await mcp_with_dash_tools.call_tool(
+        "delete_dashboard_tab",
+        {"dashboard_id": 1, "tab_id": 10},
+    )
+    mock_client.delete_dashboard_tab.assert_awaited_once_with(1, 10)
+    data = json.loads(result.content[0].text)
+    assert data["status"] == "success"
+    assert data["tab_id"] == 10
+    assert data["action"] == "deleted"


### PR DESCRIPTION
## Summary

- Adds 3 new MCP tools for dashboard tab management: `create_dashboard_tab`, `update_dashboard_tab`, `delete_dashboard_tab`
- Uses Metabase's atomic `PUT /api/dashboard/:id` approach (dedicated tab endpoints don't exist in v0.58+)
- Extracts `_clean_dashcards()` static helper to eliminate duplication with `add_card_to_dashboard`
- `delete_dashboard_tab` also removes orphaned dashcards assigned to the deleted tab

Closes #21

## Test plan

- [x] `ruff check` — all checks passed
- [x] `mypy` — 0 issues in 14 source files
- [x] 193 unit tests passed (3 new tab tool tests)
- [x] 20 integration tests passed on Metabase v0.58.7 (1 new tab CRUD cycle test)
- [x] Verified `add_card_to_dashboard` still works after `_clean_dashcards` refactor (integration test `test_dashboard_with_card` passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)