### PR TITLE
feat: add dashboard parameter tools (get filter values, search)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Dashboard parameter tools: `get_dashboard_param_values`, `search_dashboard_param_values` (#23)
 - Dashboard tab management tools: `create_dashboard_tab`, `update_dashboard_tab`, `delete_dashboard_tab` (#21)
 - `_clean_dashcards()` static helper to normalize dashcard payloads, reused across tab and card operations (#21)
 - Session token automatic refresh with TTL tracking and 401-based re-authentication in `MetabaseAuth` (#2)

--- a/src/metabase_mcp/client.py
+++ b/src/metabase_mcp/client.py
@@ -294,6 +294,23 @@ class MetabaseClient:
             "POST", f"/api/dashboard/save/collection/{parent_collection_id}", json=dashboard
         )
 
+    # ── Dashboard parameter operations ──────────────────────────────────────
+
+    async def get_dashboard_param_values(
+        self, dashboard_id: int, param_key: str
+    ) -> Any:
+        return await self._request(
+            "GET", f"/api/dashboard/{dashboard_id}/params/{param_key}/values"
+        )
+
+    async def search_dashboard_param_values(
+        self, dashboard_id: int, param_key: str, query: str
+    ) -> Any:
+        return await self._request(
+            "GET",
+            f"/api/dashboard/{dashboard_id}/params/{param_key}/search/{query}",
+        )
+
     # ── Dashboard tab operations ──────────────────────────────────────────
     #
     # Metabase manages tabs atomically through PUT /api/dashboard/:id

--- a/src/metabase_mcp/tools/dashboard.py
+++ b/src/metabase_mcp/tools/dashboard.py
@@ -364,6 +364,46 @@ def register_dashboard_tools(mcp: FastMCP, client: MetabaseClient) -> None:
             indent=2,
         )
 
+    # ── Dashboard parameter tools ──────────────────────────────────────
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def get_dashboard_param_values(
+        dashboard_id: Annotated[int, Field(description="The ID of the dashboard")],
+        param_key: Annotated[
+            str,
+            Field(
+                description="The parameter ID (from the dashboard's 'parameters' array, e.g. 'fc2cd1be')"
+            ),
+        ],
+    ) -> str:
+        """Get possible values for a dashboard filter parameter - use this to discover what values are available for a specific filter before applying it"""
+        result = await client.get_dashboard_param_values(dashboard_id, param_key)
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def search_dashboard_param_values(
+        dashboard_id: Annotated[int, Field(description="The ID of the dashboard")],
+        param_key: Annotated[
+            str,
+            Field(
+                description="The parameter ID (from the dashboard's 'parameters' array)"
+            ),
+        ],
+        query: Annotated[
+            str,
+            Field(description="Search query to filter parameter values"),
+        ],
+    ) -> str:
+        """Search for specific values within a dashboard filter parameter - use this to find matching filter values by keyword instead of listing all"""
+        result = await client.search_dashboard_param_values(
+            dashboard_id, param_key, query
+        )
+        return json.dumps(result, indent=2)
+
     # ── Write tools ─────────────────────────────────────────────────────
 
     @mcp.tool(

--- a/tests/integration/test_dashboards.py
+++ b/tests/integration/test_dashboards.py
@@ -146,3 +146,32 @@ async def test_dashboard_tab_crud(
 
     finally:
         await client.delete_dashboard(dashboard_id, hard_delete=True)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_dashboard_param_values(client: MetabaseClient) -> None:
+    """Get and search parameter values on dashboard with filters."""
+    # Dashboard 1 (E-commerce insights) has a Category parameter with id "5eeec658"
+    dashboards = await client.get_dashboards()
+    if not dashboards:
+        pytest.skip("No dashboards available")
+    # Find a dashboard with parameters
+    dashboard = await client.get_dashboard(dashboards[0]["id"])
+    params = dashboard.get("parameters", [])
+    if not params:
+        pytest.skip("No parameters on first dashboard")
+
+    param_key = params[0]["id"]
+    dashboard_id = dashboard["id"]
+
+    # Get values
+    values = await client.get_dashboard_param_values(dashboard_id, param_key)
+    assert "values" in values
+
+    # Search values (use first char of first value if available)
+    if values.get("values"):
+        first_val = values["values"][0][0]
+        search = await client.search_dashboard_param_values(
+            dashboard_id, param_key, str(first_val)[:3]
+        )
+        assert "values" in search

--- a/tests/tools/test_dashboard.py
+++ b/tests/tools/test_dashboard.py
@@ -624,3 +624,41 @@ async def test_delete_dashboard_tab_tool(
     assert data["status"] == "success"
     assert data["tab_id"] == 10
     assert data["action"] == "deleted"
+
+
+# ── Dashboard parameter tools ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_dashboard_param_values_tool(
+    mcp_with_dash_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.get_dashboard_param_values.return_value = {
+        "values": [["Gadget"], ["Widget"]],
+        "has_more_values": False,
+    }
+    result = await mcp_with_dash_tools.call_tool(
+        "get_dashboard_param_values",
+        {"dashboard_id": 1, "param_key": "abc123"},
+    )
+    mock_client.get_dashboard_param_values.assert_awaited_once_with(1, "abc123")
+    data = json.loads(result.content[0].text)
+    assert len(data["values"]) == 2
+    assert data["has_more_values"] is False
+
+
+@pytest.mark.asyncio
+async def test_search_dashboard_param_values_tool(
+    mcp_with_dash_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.search_dashboard_param_values.return_value = {
+        "values": [["Gadget"]],
+        "has_more_values": False,
+    }
+    result = await mcp_with_dash_tools.call_tool(
+        "search_dashboard_param_values",
+        {"dashboard_id": 1, "param_key": "abc123", "query": "Gad"},
+    )
+    mock_client.search_dashboard_param_values.assert_awaited_once_with(1, "abc123", "Gad")
+    data = json.loads(result.content[0].text)
+    assert data["values"] == [["Gadget"]]


### PR DESCRIPTION
## Summary

- Adds `get_dashboard_param_values` and `search_dashboard_param_values` tools
- Enables agents to discover available filter values before applying dashboard filters
- Available in "all" mode (read-only, non-essential)

Closes #23

## Test plan

- [x] 195 unit tests passed (2 new)
- [x] Integration test passed on Metabase v0.58.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)