### PR TITLE
feat: add field management tools (get, update, values, summary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Field management tools: `get_field`, `update_field`, `get_field_values`, `get_field_summary`, `search_field_values`, `rescan_field_values`, `discard_field_values` (#24)
 - Dashboard parameter tools: `get_dashboard_param_values`, `search_dashboard_param_values` (#23)
 - Dashboard tab management tools: `create_dashboard_tab`, `update_dashboard_tab`, `delete_dashboard_tab` (#21)
 - `_clean_dashcards()` static helper to normalize dashcard payloads, reused across tab and card operations (#21)

--- a/src/metabase_mcp/client.py
+++ b/src/metabase_mcp/client.py
@@ -818,6 +818,33 @@ class MetabaseClient:
             "GET", f"/api/table/{table_id}/data", params={"limit": str(limit)}
         )
 
+    # ── Field operations ──────────────────────────────────────────────────
+
+    async def get_field(self, field_id: int) -> Any:
+        return await self._request("GET", f"/api/field/{field_id}")
+
+    async def update_field(self, field_id: int, updates: dict[str, Any]) -> Any:
+        return await self._request("PUT", f"/api/field/{field_id}", json=updates)
+
+    async def get_field_values(self, field_id: int) -> Any:
+        return await self._request("GET", f"/api/field/{field_id}/values")
+
+    async def get_field_summary(self, field_id: int) -> Any:
+        return await self._request("GET", f"/api/field/{field_id}/summary")
+
+    async def search_field_values(
+        self, field_id: int, search_field_id: int
+    ) -> Any:
+        return await self._request(
+            "GET", f"/api/field/{field_id}/search/{search_field_id}"
+        )
+
+    async def rescan_field_values(self, field_id: int) -> Any:
+        return await self._request("POST", f"/api/field/{field_id}/rescan_values")
+
+    async def discard_field_values(self, field_id: int) -> Any:
+        return await self._request("POST", f"/api/field/{field_id}/discard_values")
+
     # ── Generic API method ───────────────────────────────────────────────
 
     async def api_call(

--- a/src/metabase_mcp/tools/__init__.py
+++ b/src/metabase_mcp/tools/__init__.py
@@ -89,6 +89,10 @@ WRITE_TOOLS: set[str] = {
     "reorder_table_fields",
     "rescan_table_field_values",
     "sync_table_schema",
+    # Field write
+    "update_field",
+    "rescan_field_values",
+    "discard_field_values",
     # Additional write
     "create_collection",
     "update_collection",
@@ -117,11 +121,13 @@ def register_all_tools(mcp: FastMCP, client: MetabaseClient, mode: str = "essent
     from metabase_mcp.tools.card import register_card_tools
     from metabase_mcp.tools.dashboard import register_dashboard_tools
     from metabase_mcp.tools.database import register_database_tools
+    from metabase_mcp.tools.field import register_field_tools
     from metabase_mcp.tools.table import register_table_tools
 
     # Register all tools first
     register_database_tools(mcp, client)
     register_table_tools(mcp, client)
+    register_field_tools(mcp, client)
     register_card_tools(mcp, client)
     register_dashboard_tools(mcp, client)
     register_additional_tools(mcp, client)

--- a/src/metabase_mcp/tools/field.py
+++ b/src/metabase_mcp/tools/field.py
@@ -1,0 +1,139 @@
+"""MCP tools for Metabase field operations."""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+from pydantic import BeforeValidator, Field
+
+from metabase_mcp.client import MetabaseClient
+from metabase_mcp.validators import parse_if_string
+
+
+def register_field_tools(mcp: FastMCP, client: MetabaseClient) -> None:
+    """Register all field-related MCP tools."""
+
+    # ── Read tools ──────────────────────────────────────────────────────
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def get_field(
+        field_id: Annotated[int, Field(description="The ID of the field")],
+    ) -> str:
+        """Get detailed information about a specific field including type, semantic type, and display settings"""
+        result = await client.get_field(field_id)
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def get_field_values(
+        field_id: Annotated[int, Field(description="The ID of the field")],
+    ) -> str:
+        """Get distinct values for a field - use this to understand value distributions or populate filter options"""
+        result = await client.get_field_values(field_id)
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def get_field_summary(
+        field_id: Annotated[int, Field(description="The ID of the field")],
+    ) -> str:
+        """Get a summary of field value distribution (count and distinct count) - use for quick data profiling"""
+        result = await client.get_field_summary(field_id)
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def search_field_values(
+        field_id: Annotated[int, Field(description="The ID of the field to search")],
+        search_field_id: Annotated[
+            int,
+            Field(description="The ID of the field to search against (for remapped fields)"),
+        ],
+    ) -> str:
+        """Search field values using a related field - use for remapped or foreign key lookups"""
+        result = await client.search_field_values(field_id, search_field_id)
+        return json.dumps(result, indent=2)
+
+    # ── Write tools ─────────────────────────────────────────────────────
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def update_field(
+        field_id: Annotated[int, Field(description="The ID of the field to update")],
+        display_name: Annotated[
+            str | None,
+            Field(description="New display name for the field"),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Field(description="New description for the field"),
+        ] = None,
+        semantic_type: Annotated[
+            str | None,
+            Field(description="Semantic type (e.g. 'type/Category', 'type/Email', 'type/FK')"),
+        ] = None,
+        visibility_type: Annotated[
+            str | None,
+            Field(description="Visibility: 'normal', 'details-only', 'hidden', or 'sensitive'"),
+        ] = None,
+        has_field_values: Annotated[
+            str | None,
+            Field(description="How to fetch values: 'none', 'list', 'search', or 'auto-list'"),
+        ] = None,
+        settings: Annotated[
+            dict[str, Any] | None,
+            BeforeValidator(parse_if_string),
+            Field(description="Custom field settings as JSON"),
+        ] = None,
+    ) -> str:
+        """Update field properties like display name, description, semantic type, or visibility - use to customize how a field appears and behaves in Metabase"""
+        updates: dict[str, Any] = {}
+        if display_name is not None:
+            updates["display_name"] = display_name
+        if description is not None:
+            updates["description"] = description
+        if semantic_type is not None:
+            updates["semantic_type"] = semantic_type
+        if visibility_type is not None:
+            updates["visibility_type"] = visibility_type
+        if has_field_values is not None:
+            updates["has_field_values"] = has_field_values
+        if settings is not None:
+            updates["settings"] = settings
+        result = await client.update_field(field_id, updates)
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def rescan_field_values(
+        field_id: Annotated[int, Field(description="The ID of the field")],
+    ) -> str:
+        """Trigger a rescan of cached field values - use after data changes to refresh filter options"""
+        await client.rescan_field_values(field_id)
+        return json.dumps(
+            {"field_id": field_id, "action": "rescan_triggered", "status": "success"},
+            indent=2,
+        )
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def discard_field_values(
+        field_id: Annotated[int, Field(description="The ID of the field")],
+    ) -> str:
+        """Discard cached field values - use to clear stale cached data for a field"""
+        await client.discard_field_values(field_id)
+        return json.dumps(
+            {"field_id": field_id, "action": "values_discarded", "status": "success"},
+            indent=2,
+        )

--- a/tests/integration/test_fields.py
+++ b/tests/integration/test_fields.py
@@ -1,0 +1,44 @@
+"""Integration tests for field operations."""
+
+from __future__ import annotations
+
+import pytest
+
+from metabase_mcp.client import MetabaseClient
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_field(client: MetabaseClient) -> None:
+    field = await client.get_field(1)
+    assert "id" in field
+    assert "name" in field
+    assert "base_type" in field
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_field_values(client: MetabaseClient) -> None:
+    values = await client.get_field_values(1)
+    assert "values" in values
+    assert "has_more_values" in values
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_field_summary(client: MetabaseClient) -> None:
+    summary = await client.get_field_summary(1)
+    assert isinstance(summary, list)
+    assert len(summary) >= 1
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_update_field_roundtrip(client: MetabaseClient) -> None:
+    """Update a field's description and restore it."""
+    original = await client.get_field(1)
+    original_desc = original.get("description")
+
+    updated = await client.update_field(1, {"description": "Integration test"})
+    assert updated["description"] == "Integration test"
+
+    # Restore
+    await client.update_field(1, {"description": original_desc})

--- a/tests/tools/test_field.py
+++ b/tests/tools/test_field.py
@@ -1,0 +1,126 @@
+"""Tests for field tool registration and execution."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp import FastMCP
+
+from metabase_mcp.tools.field import register_field_tools
+
+
+@pytest.fixture
+def mcp_with_field_tools(mcp: FastMCP, mock_client: AsyncMock) -> FastMCP:
+    register_field_tools(mcp, mock_client)
+    return mcp
+
+
+# ── Read tools ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_field_tool(
+    mcp_with_field_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.get_field.return_value = {
+        "id": 1,
+        "name": "CATEGORY",
+        "display_name": "Category",
+        "base_type": "type/Text",
+    }
+    result = await mcp_with_field_tools.call_tool("get_field", {"field_id": 1})
+    mock_client.get_field.assert_awaited_once_with(1)
+    data = json.loads(result.content[0].text)
+    assert data["name"] == "CATEGORY"
+
+
+@pytest.mark.asyncio
+async def test_get_field_values_tool(
+    mcp_with_field_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.get_field_values.return_value = {
+        "field_id": 1,
+        "values": [["Gadget"], ["Widget"]],
+        "has_more_values": False,
+    }
+    result = await mcp_with_field_tools.call_tool("get_field_values", {"field_id": 1})
+    mock_client.get_field_values.assert_awaited_once_with(1)
+    data = json.loads(result.content[0].text)
+    assert len(data["values"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_field_summary_tool(
+    mcp_with_field_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.get_field_summary.return_value = [["count", 2495], ["distincts", 102]]
+    result = await mcp_with_field_tools.call_tool("get_field_summary", {"field_id": 1})
+    mock_client.get_field_summary.assert_awaited_once_with(1)
+    data = json.loads(result.content[0].text)
+    assert data[0] == ["count", 2495]
+
+
+@pytest.mark.asyncio
+async def test_search_field_values_tool(
+    mcp_with_field_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.search_field_values.return_value = [["Gadget", 1], ["Gizmo", 2]]
+    result = await mcp_with_field_tools.call_tool(
+        "search_field_values", {"field_id": 1, "search_field_id": 2}
+    )
+    mock_client.search_field_values.assert_awaited_once_with(1, 2)
+    data = json.loads(result.content[0].text)
+    assert len(data) == 2
+
+
+# ── Write tools ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_field_tool(
+    mcp_with_field_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.update_field.return_value = {
+        "id": 1,
+        "display_name": "New Name",
+        "description": "New desc",
+    }
+    result = await mcp_with_field_tools.call_tool(
+        "update_field",
+        {"field_id": 1, "display_name": "New Name", "description": "New desc"},
+    )
+    mock_client.update_field.assert_awaited_once_with(
+        1, {"display_name": "New Name", "description": "New desc"}
+    )
+    data = json.loads(result.content[0].text)
+    assert data["display_name"] == "New Name"
+
+
+@pytest.mark.asyncio
+async def test_rescan_field_values_tool(
+    mcp_with_field_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.rescan_field_values.return_value = None
+    result = await mcp_with_field_tools.call_tool(
+        "rescan_field_values", {"field_id": 1}
+    )
+    mock_client.rescan_field_values.assert_awaited_once_with(1)
+    data = json.loads(result.content[0].text)
+    assert data["status"] == "success"
+    assert data["action"] == "rescan_triggered"
+
+
+@pytest.mark.asyncio
+async def test_discard_field_values_tool(
+    mcp_with_field_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.discard_field_values.return_value = None
+    result = await mcp_with_field_tools.call_tool(
+        "discard_field_values", {"field_id": 1}
+    )
+    mock_client.discard_field_values.assert_awaited_once_with(1)
+    data = json.loads(result.content[0].text)
+    assert data["status"] == "success"
+    assert data["action"] == "values_discarded"


### PR DESCRIPTION
## Summary

- Adds 7 new MCP tools for field operations in new `tools/field.py` module
- Read tools: `get_field`, `get_field_values`, `get_field_summary`, `search_field_values`
- Write tools: `update_field`, `rescan_field_values`, `discard_field_values`
- Enables agents to understand field types, value distributions, and customize field display

Closes #24

## Test plan

- [x] 202 unit tests passed (7 new)
- [x] 4 integration tests passed on Metabase v0.58.7 (including update roundtrip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)