### PR TITLE
feat: add action tools (CRUD + execute)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Action tools: `list_actions`, `get_action`, `create_action`, `update_action`, `delete_action`, `execute_action` (#25)
 - Field management tools: `get_field`, `update_field`, `get_field_values`, `get_field_summary`, `search_field_values`, `rescan_field_values`, `discard_field_values` (#24)
 - Dashboard parameter tools: `get_dashboard_param_values`, `search_dashboard_param_values` (#23)
 - Dashboard tab management tools: `create_dashboard_tab`, `update_dashboard_tab`, `delete_dashboard_tab` (#21)

--- a/src/metabase_mcp/client.py
+++ b/src/metabase_mcp/client.py
@@ -818,6 +818,32 @@ class MetabaseClient:
             "GET", f"/api/table/{table_id}/data", params={"limit": str(limit)}
         )
 
+    # ── Action operations ─────────────────────────────────────────────────
+
+    async def get_actions(self) -> Any:
+        return await self._request("GET", "/api/action")
+
+    async def get_action(self, action_id: int) -> Any:
+        return await self._request("GET", f"/api/action/{action_id}")
+
+    async def create_action(self, action: dict[str, Any]) -> Any:
+        return await self._request("POST", "/api/action", json=action)
+
+    async def update_action(self, action_id: int, updates: dict[str, Any]) -> Any:
+        return await self._request("PUT", f"/api/action/{action_id}", json=updates)
+
+    async def delete_action(self, action_id: int) -> Any:
+        return await self._request("DELETE", f"/api/action/{action_id}")
+
+    async def execute_action(
+        self, action_id: int, parameters: dict[str, Any] | None = None
+    ) -> Any:
+        return await self._request(
+            "POST",
+            f"/api/action/{action_id}/execute",
+            json={"parameters": parameters or {}},
+        )
+
     # ── Field operations ──────────────────────────────────────────────────
 
     async def get_field(self, field_id: int) -> Any:

--- a/src/metabase_mcp/tools/__init__.py
+++ b/src/metabase_mcp/tools/__init__.py
@@ -89,6 +89,11 @@ WRITE_TOOLS: set[str] = {
     "reorder_table_fields",
     "rescan_table_field_values",
     "sync_table_schema",
+    # Action write
+    "create_action",
+    "update_action",
+    "delete_action",
+    "execute_action",
     # Field write
     "update_field",
     "rescan_field_values",
@@ -117,6 +122,7 @@ def register_all_tools(mcp: FastMCP, client: MetabaseClient, mode: str = "essent
 
     After registering all tools, removes those that don't match the current mode.
     """
+    from metabase_mcp.tools.action import register_action_tools
     from metabase_mcp.tools.additional import register_additional_tools
     from metabase_mcp.tools.card import register_card_tools
     from metabase_mcp.tools.dashboard import register_dashboard_tools
@@ -130,6 +136,7 @@ def register_all_tools(mcp: FastMCP, client: MetabaseClient, mode: str = "essent
     register_field_tools(mcp, client)
     register_card_tools(mcp, client)
     register_dashboard_tools(mcp, client)
+    register_action_tools(mcp, client)
     register_additional_tools(mcp, client)
 
     if mode == "all":

--- a/src/metabase_mcp/tools/action.py
+++ b/src/metabase_mcp/tools/action.py
@@ -1,0 +1,137 @@
+"""MCP tools for Metabase action operations."""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+from pydantic import BeforeValidator, Field
+
+from metabase_mcp.client import MetabaseClient
+from metabase_mcp.validators import parse_if_string
+
+
+def register_action_tools(mcp: FastMCP, client: MetabaseClient) -> None:
+    """Register all action-related MCP tools."""
+
+    # ── Read tools ──────────────────────────────────────────────────────
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def list_actions() -> str:
+        """List all actions - use this to discover available write-back actions or custom HTTP actions"""
+        result = await client.get_actions()
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def get_action(
+        action_id: Annotated[int, Field(description="The ID of the action")],
+    ) -> str:
+        """Get detailed information about a specific action including its query, parameters, and settings"""
+        result = await client.get_action(action_id)
+        return json.dumps(result, indent=2)
+
+    # ── Write tools ─────────────────────────────────────────────────────
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def create_action(
+        name: Annotated[str, Field(description="Name of the action")],
+        model_id: Annotated[int, Field(description="The ID of the model this action belongs to")],
+        type: Annotated[
+            str,
+            Field(description="Action type: 'query' (SQL), 'implicit', or 'http'"),
+        ],
+        database_id: Annotated[
+            int | None,
+            Field(description="Database ID (required for query actions)"),
+        ] = None,
+        dataset_query: Annotated[
+            dict[str, Any] | None,
+            BeforeValidator(parse_if_string),
+            Field(description="The query definition (for query-type actions)"),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Field(description="Description of the action"),
+        ] = None,
+        parameters: Annotated[
+            list[dict[str, Any]] | None,
+            BeforeValidator(parse_if_string),
+            Field(description="Action parameters definition"),
+        ] = None,
+    ) -> str:
+        """Create a new action (query, implicit, or HTTP) on a model - use this to enable write-back operations on databases through Metabase"""
+        action_data: dict[str, Any] = {
+            "name": name,
+            "model_id": model_id,
+            "type": type,
+        }
+        if database_id is not None:
+            action_data["database_id"] = database_id
+        if dataset_query is not None:
+            action_data["dataset_query"] = dataset_query
+        if description is not None:
+            action_data["description"] = description
+        if parameters is not None:
+            action_data["parameters"] = parameters
+        result = await client.create_action(action_data)
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def update_action(
+        action_id: Annotated[int, Field(description="The ID of the action to update")],
+        name: Annotated[str | None, Field(description="New name")] = None,
+        description: Annotated[str | None, Field(description="New description")] = None,
+        dataset_query: Annotated[
+            dict[str, Any] | None,
+            BeforeValidator(parse_if_string),
+            Field(description="Updated query definition"),
+        ] = None,
+    ) -> str:
+        """Update an existing action's properties - use this to modify action queries, names, or settings"""
+        updates: dict[str, Any] = {}
+        if name is not None:
+            updates["name"] = name
+        if description is not None:
+            updates["description"] = description
+        if dataset_query is not None:
+            updates["dataset_query"] = dataset_query
+        result = await client.update_action(action_id, updates)
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+    )
+    async def delete_action(
+        action_id: Annotated[int, Field(description="The ID of the action to delete")],
+    ) -> str:
+        """Delete an action - WARNING: this permanently removes the action"""
+        await client.delete_action(action_id)
+        return json.dumps(
+            {"action_id": action_id, "action": "deleted", "status": "success"},
+            indent=2,
+        )
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def execute_action(
+        action_id: Annotated[int, Field(description="The ID of the action to execute")],
+        parameters: Annotated[
+            dict[str, Any] | None,
+            BeforeValidator(parse_if_string),
+            Field(description="Parameters to pass to the action as JSON"),
+        ] = None,
+    ) -> str:
+        """Execute an action with optional parameters - use this to trigger write-back operations, custom HTTP calls, or implicit CRUD actions"""
+        result = await client.execute_action(action_id, parameters)
+        return json.dumps(result, indent=2)

--- a/tests/integration/test_actions.py
+++ b/tests/integration/test_actions.py
@@ -1,0 +1,16 @@
+"""Integration tests for action operations."""
+
+from __future__ import annotations
+
+import pytest
+
+from metabase_mcp.client import MetabaseClient
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_list_actions(client: MetabaseClient) -> None:
+    """List actions endpoint is accessible (may return empty if actions not enabled)."""
+    actions = await client.get_actions()
+    assert isinstance(actions, list)

--- a/tests/tools/test_action.py
+++ b/tests/tools/test_action.py
@@ -1,0 +1,95 @@
+"""Tests for action tool registration and execution."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp import FastMCP
+
+from metabase_mcp.tools.action import register_action_tools
+
+
+@pytest.fixture
+def mcp_with_action_tools(mcp: FastMCP, mock_client: AsyncMock) -> FastMCP:
+    register_action_tools(mcp, mock_client)
+    return mcp
+
+
+@pytest.mark.asyncio
+async def test_list_actions_tool(
+    mcp_with_action_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.get_actions.return_value = [{"id": 1, "name": "Insert Order", "type": "query"}]
+    result = await mcp_with_action_tools.call_tool("list_actions", {})
+    mock_client.get_actions.assert_awaited_once()
+    data = json.loads(result.content[0].text)
+    assert len(data) == 1
+    assert data[0]["name"] == "Insert Order"
+
+
+@pytest.mark.asyncio
+async def test_get_action_tool(
+    mcp_with_action_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.get_action.return_value = {"id": 1, "name": "Insert Order", "type": "query"}
+    result = await mcp_with_action_tools.call_tool("get_action", {"action_id": 1})
+    mock_client.get_action.assert_awaited_once_with(1)
+    data = json.loads(result.content[0].text)
+    assert data["name"] == "Insert Order"
+
+
+@pytest.mark.asyncio
+async def test_create_action_tool(
+    mcp_with_action_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.create_action.return_value = {"id": 1, "name": "New Action", "type": "query"}
+    result = await mcp_with_action_tools.call_tool(
+        "create_action",
+        {"name": "New Action", "model_id": 2, "type": "query", "database_id": 1},
+    )
+    mock_client.create_action.assert_awaited_once()
+    call_args = mock_client.create_action.call_args[0][0]
+    assert call_args["name"] == "New Action"
+    assert call_args["model_id"] == 2
+    assert call_args["database_id"] == 1
+    data = json.loads(result.content[0].text)
+    assert data["id"] == 1
+
+
+@pytest.mark.asyncio
+async def test_update_action_tool(
+    mcp_with_action_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.update_action.return_value = {"id": 1, "name": "Updated"}
+    result = await mcp_with_action_tools.call_tool(
+        "update_action", {"action_id": 1, "name": "Updated"}
+    )
+    mock_client.update_action.assert_awaited_once_with(1, {"name": "Updated"})
+    data = json.loads(result.content[0].text)
+    assert data["name"] == "Updated"
+
+
+@pytest.mark.asyncio
+async def test_delete_action_tool(
+    mcp_with_action_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.delete_action.return_value = None
+    result = await mcp_with_action_tools.call_tool("delete_action", {"action_id": 1})
+    mock_client.delete_action.assert_awaited_once_with(1)
+    data = json.loads(result.content[0].text)
+    assert data["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_execute_action_tool(
+    mcp_with_action_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.execute_action.return_value = {"rows_affected": 1}
+    result = await mcp_with_action_tools.call_tool(
+        "execute_action", {"action_id": 1, "parameters": {"name": "test"}}
+    )
+    mock_client.execute_action.assert_awaited_once_with(1, {"name": "test"})
+    data = json.loads(result.content[0].text)
+    assert data["rows_affected"] == 1


### PR DESCRIPTION
## Summary

- Adds 6 new MCP tools for Metabase actions in new `tools/action.py` module
- Read: `list_actions`, `get_action`
- Write: `create_action`, `update_action`, `delete_action`, `execute_action`
- Enables agents to perform write-back operations through Metabase models
- Note: actions must be enabled per-database in Metabase settings

Closes #25

## Test plan

- [x] 208 unit tests passed (6 new)
- [x] Integration test passed (list_actions endpoint accessible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)