### PR TITLE
feat: add notification and alert tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Notification and alert tools: `list_notifications`, `get_notification`, `create_notification`, `update_notification`, `send_notification`, `unsubscribe_notification`, `list_alerts`, `get_alert` (#26)
 - Action tools: `list_actions`, `get_action`, `create_action`, `update_action`, `delete_action`, `execute_action` (#25)
 - Field management tools: `get_field`, `update_field`, `get_field_values`, `get_field_summary`, `search_field_values`, `rescan_field_values`, `discard_field_values` (#24)
 - Dashboard parameter tools: `get_dashboard_param_values`, `search_dashboard_param_values` (#23)

--- a/src/metabase_mcp/client.py
+++ b/src/metabase_mcp/client.py
@@ -818,6 +818,42 @@ class MetabaseClient:
             "GET", f"/api/table/{table_id}/data", params={"limit": str(limit)}
         )
 
+    # ── Notification operations ─────────────────────────────────────────────
+
+    async def get_notifications(self) -> Any:
+        return await self._request("GET", "/api/notification")
+
+    async def get_notification(self, notification_id: int) -> Any:
+        return await self._request("GET", f"/api/notification/{notification_id}")
+
+    async def create_notification(self, notification: dict[str, Any]) -> Any:
+        return await self._request("POST", "/api/notification", json=notification)
+
+    async def update_notification(
+        self, notification_id: int, updates: dict[str, Any]
+    ) -> Any:
+        return await self._request(
+            "PUT", f"/api/notification/{notification_id}", json=updates
+        )
+
+    async def send_notification(self, notification_id: int) -> Any:
+        return await self._request(
+            "POST", f"/api/notification/{notification_id}/send"
+        )
+
+    async def unsubscribe_notification(self, notification_id: int) -> Any:
+        return await self._request(
+            "POST", f"/api/notification/{notification_id}/unsubscribe"
+        )
+
+    # ── Alert operations (legacy) ────────────────────────────────────────
+
+    async def get_alerts(self) -> Any:
+        return await self._request("GET", "/api/alert")
+
+    async def get_alert(self, alert_id: int) -> Any:
+        return await self._request("GET", f"/api/alert/{alert_id}")
+
     # ── Action operations ─────────────────────────────────────────────────
 
     async def get_actions(self) -> Any:

--- a/src/metabase_mcp/tools/__init__.py
+++ b/src/metabase_mcp/tools/__init__.py
@@ -89,6 +89,11 @@ WRITE_TOOLS: set[str] = {
     "reorder_table_fields",
     "rescan_table_field_values",
     "sync_table_schema",
+    # Notification write
+    "create_notification",
+    "update_notification",
+    "send_notification",
+    "unsubscribe_notification",
     # Action write
     "create_action",
     "update_action",
@@ -128,6 +133,7 @@ def register_all_tools(mcp: FastMCP, client: MetabaseClient, mode: str = "essent
     from metabase_mcp.tools.dashboard import register_dashboard_tools
     from metabase_mcp.tools.database import register_database_tools
     from metabase_mcp.tools.field import register_field_tools
+    from metabase_mcp.tools.notification import register_notification_tools
     from metabase_mcp.tools.table import register_table_tools
 
     # Register all tools first
@@ -137,6 +143,7 @@ def register_all_tools(mcp: FastMCP, client: MetabaseClient, mode: str = "essent
     register_card_tools(mcp, client)
     register_dashboard_tools(mcp, client)
     register_action_tools(mcp, client)
+    register_notification_tools(mcp, client)
     register_additional_tools(mcp, client)
 
     if mode == "all":

--- a/src/metabase_mcp/tools/notification.py
+++ b/src/metabase_mcp/tools/notification.py
@@ -1,0 +1,133 @@
+"""MCP tools for Metabase notification and alert operations."""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+from pydantic import BeforeValidator, Field
+
+from metabase_mcp.client import MetabaseClient
+from metabase_mcp.validators import parse_if_string
+
+
+def register_notification_tools(mcp: FastMCP, client: MetabaseClient) -> None:
+    """Register all notification and alert-related MCP tools."""
+
+    # ── Read tools ──────────────────────────────────────────────────────
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def list_notifications() -> str:
+        """List all notifications - use this to see configured alerts and subscriptions"""
+        result = await client.get_notifications()
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def get_notification(
+        notification_id: Annotated[int, Field(description="The ID of the notification")],
+    ) -> str:
+        """Get detailed information about a specific notification including handlers and subscriptions"""
+        result = await client.get_notification(notification_id)
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def list_alerts() -> str:
+        """List all legacy alerts - use this to see configured card-based alerts (being replaced by notifications)"""
+        result = await client.get_alerts()
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def get_alert(
+        alert_id: Annotated[int, Field(description="The ID of the alert")],
+    ) -> str:
+        """Get detailed information about a specific legacy alert"""
+        result = await client.get_alert(alert_id)
+        return json.dumps(result, indent=2)
+
+    # ── Write tools ─────────────────────────────────────────────────────
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def create_notification(
+        payload_type: Annotated[
+            str,
+            Field(description="Notification type (e.g. 'notification/card')"),
+        ],
+        payload: Annotated[
+            dict[str, Any],
+            BeforeValidator(parse_if_string),
+            Field(description="Notification payload as JSON (varies by type)"),
+        ],
+        handlers: Annotated[
+            list[dict[str, Any]],
+            BeforeValidator(parse_if_string),
+            Field(description="Notification handlers (channels and templates) as JSON"),
+        ],
+        subscriptions: Annotated[
+            list[dict[str, Any]] | None,
+            BeforeValidator(parse_if_string),
+            Field(description="Subscriptions list as JSON"),
+        ] = None,
+    ) -> str:
+        """Create a new notification - use this to set up automated alerts on cards or dashboards"""
+        notification_data: dict[str, Any] = {
+            "payload_type": payload_type,
+            "payload": payload,
+            "handlers": handlers,
+        }
+        if subscriptions is not None:
+            notification_data["subscriptions"] = subscriptions
+        result = await client.create_notification(notification_data)
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def update_notification(
+        notification_id: Annotated[int, Field(description="The ID of the notification to update")],
+        updates: Annotated[
+            dict[str, Any],
+            BeforeValidator(parse_if_string),
+            Field(description="Updates to apply as JSON (e.g. active, handlers, subscriptions)"),
+        ],
+    ) -> str:
+        """Update a notification's settings - use this to modify handlers, subscriptions, or activate/deactivate"""
+        result = await client.update_notification(notification_id, updates)
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def send_notification(
+        notification_id: Annotated[int, Field(description="The ID of the notification to send")],
+    ) -> str:
+        """Manually trigger a notification to send now - use this to test or force-send a notification"""
+        result = await client.send_notification(notification_id)
+        return json.dumps(
+            result if result else {"notification_id": notification_id, "action": "sent", "status": "success"},
+            indent=2,
+        )
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def unsubscribe_notification(
+        notification_id: Annotated[int, Field(description="The ID of the notification to unsubscribe from")],
+    ) -> str:
+        """Unsubscribe the current user from a notification"""
+        result = await client.unsubscribe_notification(notification_id)
+        return json.dumps(
+            result if result else {"notification_id": notification_id, "action": "unsubscribed", "status": "success"},
+            indent=2,
+        )

--- a/tests/integration/test_notifications.py
+++ b/tests/integration/test_notifications.py
@@ -1,0 +1,31 @@
+"""Integration tests for notification and alert operations."""
+
+from __future__ import annotations
+
+import pytest
+
+from metabase_mcp.client import MetabaseClient
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_list_notifications(client: MetabaseClient) -> None:
+    notifications = await client.get_notifications()
+    assert isinstance(notifications, list)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_notification(client: MetabaseClient) -> None:
+    notifications = await client.get_notifications()
+    if not notifications:
+        pytest.skip("No notifications available")
+    notif = await client.get_notification(notifications[0]["id"])
+    assert "id" in notif
+    assert "payload_type" in notif
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_list_alerts(client: MetabaseClient) -> None:
+    alerts = await client.get_alerts()
+    assert isinstance(alerts, list)

--- a/tests/tools/test_notification.py
+++ b/tests/tools/test_notification.py
@@ -1,0 +1,119 @@
+"""Tests for notification tool registration and execution."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp import FastMCP
+
+from metabase_mcp.tools.notification import register_notification_tools
+
+
+@pytest.fixture
+def mcp_with_notif_tools(mcp: FastMCP, mock_client: AsyncMock) -> FastMCP:
+    register_notification_tools(mcp, mock_client)
+    return mcp
+
+
+@pytest.mark.asyncio
+async def test_list_notifications_tool(
+    mcp_with_notif_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.get_notifications.return_value = [{"id": 1, "payload_type": "notification/card"}]
+    result = await mcp_with_notif_tools.call_tool("list_notifications", {})
+    mock_client.get_notifications.assert_awaited_once()
+    data = json.loads(result.content[0].text)
+    assert len(data) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_notification_tool(
+    mcp_with_notif_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.get_notification.return_value = {"id": 1, "payload_type": "notification/card"}
+    result = await mcp_with_notif_tools.call_tool("get_notification", {"notification_id": 1})
+    mock_client.get_notification.assert_awaited_once_with(1)
+    data = json.loads(result.content[0].text)
+    assert data["id"] == 1
+
+
+@pytest.mark.asyncio
+async def test_list_alerts_tool(
+    mcp_with_notif_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.get_alerts.return_value = []
+    result = await mcp_with_notif_tools.call_tool("list_alerts", {})
+    mock_client.get_alerts.assert_awaited_once()
+    data = json.loads(result.content[0].text)
+    assert data == []
+
+
+@pytest.mark.asyncio
+async def test_get_alert_tool(
+    mcp_with_notif_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.get_alert.return_value = {"id": 1, "card": {"id": 5}}
+    result = await mcp_with_notif_tools.call_tool("get_alert", {"alert_id": 1})
+    mock_client.get_alert.assert_awaited_once_with(1)
+    data = json.loads(result.content[0].text)
+    assert data["id"] == 1
+
+
+@pytest.mark.asyncio
+async def test_create_notification_tool(
+    mcp_with_notif_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.create_notification.return_value = {"id": 10, "payload_type": "notification/card"}
+    result = await mcp_with_notif_tools.call_tool(
+        "create_notification",
+        {
+            "payload_type": "notification/card",
+            "payload": {"card_id": 5},
+            "handlers": [{"channel_type": "channel/email"}],
+        },
+    )
+    mock_client.create_notification.assert_awaited_once()
+    data = json.loads(result.content[0].text)
+    assert data["id"] == 10
+
+
+@pytest.mark.asyncio
+async def test_update_notification_tool(
+    mcp_with_notif_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.update_notification.return_value = {"id": 1, "active": False}
+    result = await mcp_with_notif_tools.call_tool(
+        "update_notification",
+        {"notification_id": 1, "updates": {"active": False}},
+    )
+    mock_client.update_notification.assert_awaited_once_with(1, {"active": False})
+    data = json.loads(result.content[0].text)
+    assert data["active"] is False
+
+
+@pytest.mark.asyncio
+async def test_send_notification_tool(
+    mcp_with_notif_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.send_notification.return_value = None
+    result = await mcp_with_notif_tools.call_tool(
+        "send_notification", {"notification_id": 1}
+    )
+    mock_client.send_notification.assert_awaited_once_with(1)
+    data = json.loads(result.content[0].text)
+    assert data["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_notification_tool(
+    mcp_with_notif_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.unsubscribe_notification.return_value = None
+    result = await mcp_with_notif_tools.call_tool(
+        "unsubscribe_notification", {"notification_id": 1}
+    )
+    mock_client.unsubscribe_notification.assert_awaited_once_with(1)
+    data = json.loads(result.content[0].text)
+    assert data["status"] == "success"


### PR DESCRIPTION
## Summary

- Adds 8 new MCP tools in new `tools/notification.py` module
- New Notification API: `list_notifications`, `get_notification`, `create_notification`, `update_notification`, `send_notification`, `unsubscribe_notification`
- Legacy Alert API: `list_alerts`, `get_alert`
- Enables agents to set up and manage automated monitoring

Closes #26

## Test plan

- [x] 216 unit tests passed (8 new)
- [x] 3 integration tests passed on Metabase v0.58.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)