### PR TITLE
feat: add bookmark tools (create, delete, list, reorder)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Bookmark tools: `list_bookmarks`, `create_bookmark`, `delete_bookmark`, `reorder_bookmarks` (#27)
 - Notification and alert tools: `list_notifications`, `get_notification`, `create_notification`, `update_notification`, `send_notification`, `unsubscribe_notification`, `list_alerts`, `get_alert` (#26)
 - Action tools: `list_actions`, `get_action`, `create_action`, `update_action`, `delete_action`, `execute_action` (#25)
 - Field management tools: `get_field`, `update_field`, `get_field_values`, `get_field_summary`, `search_field_values`, `rescan_field_values`, `discard_field_values` (#24)

--- a/src/metabase_mcp/client.py
+++ b/src/metabase_mcp/client.py
@@ -818,6 +818,22 @@ class MetabaseClient:
             "GET", f"/api/table/{table_id}/data", params={"limit": str(limit)}
         )
 
+    # ── Bookmark operations ────────────────────────────────────────────────
+
+    async def get_bookmarks(self) -> Any:
+        return await self._request("GET", "/api/bookmark")
+
+    async def create_bookmark(self, model: str, model_id: int) -> Any:
+        return await self._request("POST", f"/api/bookmark/{model}/{model_id}")
+
+    async def delete_bookmark(self, model: str, model_id: int) -> Any:
+        return await self._request("DELETE", f"/api/bookmark/{model}/{model_id}")
+
+    async def reorder_bookmarks(self, orderings: list[dict[str, Any]]) -> Any:
+        return await self._request(
+            "PUT", "/api/bookmark/ordering", json={"orderings": orderings}
+        )
+
     # ── Notification operations ─────────────────────────────────────────────
 
     async def get_notifications(self) -> Any:

--- a/src/metabase_mcp/tools/__init__.py
+++ b/src/metabase_mcp/tools/__init__.py
@@ -103,6 +103,10 @@ WRITE_TOOLS: set[str] = {
     "update_field",
     "rescan_field_values",
     "discard_field_values",
+    # Bookmark write
+    "create_bookmark",
+    "delete_bookmark",
+    "reorder_bookmarks",
     # Additional write
     "create_collection",
     "update_collection",
@@ -129,6 +133,7 @@ def register_all_tools(mcp: FastMCP, client: MetabaseClient, mode: str = "essent
     """
     from metabase_mcp.tools.action import register_action_tools
     from metabase_mcp.tools.additional import register_additional_tools
+    from metabase_mcp.tools.bookmark import register_bookmark_tools
     from metabase_mcp.tools.card import register_card_tools
     from metabase_mcp.tools.dashboard import register_dashboard_tools
     from metabase_mcp.tools.database import register_database_tools
@@ -144,6 +149,7 @@ def register_all_tools(mcp: FastMCP, client: MetabaseClient, mode: str = "essent
     register_dashboard_tools(mcp, client)
     register_action_tools(mcp, client)
     register_notification_tools(mcp, client)
+    register_bookmark_tools(mcp, client)
     register_additional_tools(mcp, client)
 
     if mode == "all":

--- a/src/metabase_mcp/tools/bookmark.py
+++ b/src/metabase_mcp/tools/bookmark.py
@@ -1,0 +1,77 @@
+"""MCP tools for Metabase bookmark operations."""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+from pydantic import BeforeValidator, Field
+
+from metabase_mcp.client import MetabaseClient
+from metabase_mcp.validators import parse_if_string
+
+
+def register_bookmark_tools(mcp: FastMCP, client: MetabaseClient) -> None:
+    """Register all bookmark-related MCP tools."""
+
+    # ── Read tools ──────────────────────────────────────────────────────
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def list_bookmarks() -> str:
+        """List all bookmarks for the current user - use this to see saved/favorited items"""
+        result = await client.get_bookmarks()
+        return json.dumps(result, indent=2)
+
+    # ── Write tools ─────────────────────────────────────────────────────
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def create_bookmark(
+        model: Annotated[
+            str,
+            Field(description="Type of item to bookmark: 'card', 'dashboard', or 'collection'"),
+        ],
+        model_id: Annotated[int, Field(description="The ID of the item to bookmark")],
+    ) -> str:
+        """Bookmark a card, dashboard, or collection for quick access"""
+        result = await client.create_bookmark(model, model_id)
+        return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+    )
+    async def delete_bookmark(
+        model: Annotated[
+            str,
+            Field(description="Type of bookmarked item: 'card', 'dashboard', or 'collection'"),
+        ],
+        model_id: Annotated[int, Field(description="The ID of the bookmarked item")],
+    ) -> str:
+        """Remove a bookmark from a card, dashboard, or collection"""
+        await client.delete_bookmark(model, model_id)
+        return json.dumps(
+            {"model": model, "model_id": model_id, "action": "deleted", "status": "success"},
+            indent=2,
+        )
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def reorder_bookmarks(
+        orderings: Annotated[
+            list[dict[str, Any]],
+            BeforeValidator(parse_if_string),
+            Field(description="List of bookmark ordering objects with 'type' and 'item_id' keys"),
+        ],
+    ) -> str:
+        """Reorder bookmarks - provide the full list in desired order"""
+        await client.reorder_bookmarks(orderings)
+        return json.dumps(
+            {"action": "reordered", "status": "success"},
+            indent=2,
+        )

--- a/tests/integration/test_bookmarks.py
+++ b/tests/integration/test_bookmarks.py
@@ -1,0 +1,37 @@
+"""Integration tests for bookmark operations."""
+
+from __future__ import annotations
+
+import pytest
+
+from metabase_mcp.client import MetabaseClient
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_list_bookmarks(client: MetabaseClient) -> None:
+    bookmarks = await client.get_bookmarks()
+    assert isinstance(bookmarks, list)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_bookmark_crud_cycle(client: MetabaseClient) -> None:
+    """Create, verify, and delete a bookmark on the Sample Database dashboard."""
+    # Use dashboard ID 1 (auto-generated Sample Database dashboard)
+    bookmarks_before = await client.get_bookmarks()
+
+    # Create bookmark
+    result = await client.create_bookmark("dashboard", 1)
+    assert "id" in result
+
+    # Verify it appears in the list
+    bookmarks_after = await client.get_bookmarks()
+    assert len(bookmarks_after) > len(bookmarks_before)
+
+    # Delete bookmark
+    await client.delete_bookmark("dashboard", 1)
+
+    # Verify it was removed
+    bookmarks_final = await client.get_bookmarks()
+    assert len(bookmarks_final) == len(bookmarks_before)

--- a/tests/tools/test_bookmark.py
+++ b/tests/tools/test_bookmark.py
@@ -1,0 +1,74 @@
+"""Tests for bookmark tool registration and execution."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp import FastMCP
+
+from metabase_mcp.tools.bookmark import register_bookmark_tools
+
+
+@pytest.fixture
+def mcp_with_bookmark_tools(mcp: FastMCP, mock_client: AsyncMock) -> FastMCP:
+    register_bookmark_tools(mcp, mock_client)
+    return mcp
+
+
+@pytest.mark.asyncio
+async def test_list_bookmarks_tool(
+    mcp_with_bookmark_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.get_bookmarks.return_value = [
+        {"id": 1, "type": "card", "item_id": 5, "name": "My Card"}
+    ]
+    result = await mcp_with_bookmark_tools.call_tool("list_bookmarks", {})
+    mock_client.get_bookmarks.assert_awaited_once()
+    data = json.loads(result.content[0].text)
+    assert len(data) == 1
+    assert data[0]["type"] == "card"
+
+
+@pytest.mark.asyncio
+async def test_create_bookmark_tool(
+    mcp_with_bookmark_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.create_bookmark.return_value = {"id": 1, "type": "card", "item_id": 5}
+    result = await mcp_with_bookmark_tools.call_tool(
+        "create_bookmark", {"model": "card", "model_id": 5}
+    )
+    mock_client.create_bookmark.assert_awaited_once_with("card", 5)
+    data = json.loads(result.content[0].text)
+    assert data["type"] == "card"
+
+
+@pytest.mark.asyncio
+async def test_delete_bookmark_tool(
+    mcp_with_bookmark_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    mock_client.delete_bookmark.return_value = None
+    result = await mcp_with_bookmark_tools.call_tool(
+        "delete_bookmark", {"model": "dashboard", "model_id": 3}
+    )
+    mock_client.delete_bookmark.assert_awaited_once_with("dashboard", 3)
+    data = json.loads(result.content[0].text)
+    assert data["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_reorder_bookmarks_tool(
+    mcp_with_bookmark_tools: FastMCP, mock_client: AsyncMock
+) -> None:
+    orderings = [
+        {"type": "card", "item_id": 5},
+        {"type": "dashboard", "item_id": 3},
+    ]
+    mock_client.reorder_bookmarks.return_value = None
+    result = await mcp_with_bookmark_tools.call_tool(
+        "reorder_bookmarks", {"orderings": orderings}
+    )
+    mock_client.reorder_bookmarks.assert_awaited_once_with(orderings)
+    data = json.loads(result.content[0].text)
+    assert data["status"] == "success"


### PR DESCRIPTION
## Summary

- Add 4 MCP tools for managing Metabase bookmarks: `list_bookmarks`, `create_bookmark`, `delete_bookmark`, `reorder_bookmarks`
- Add client methods: `get_bookmarks`, `create_bookmark`, `delete_bookmark`, `reorder_bookmarks`
- Register bookmark tools in `__init__.py` with write tools in `WRITE_TOOLS` set

## Test plan

- [x] 4 unit tests covering all tools (mock-based)
- [x] 2 integration tests: list bookmarks + full CRUD cycle (create → verify → delete → verify)
- [x] ruff check clean
- [x] mypy clean
- [x] 220/220 unit tests passing
- [x] Integration tests passing against real Metabase v0.58.7

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)